### PR TITLE
Support Latest 035 and SH + More Configs and Cleanup

### DIFF
--- a/DCReplace/Config.cs
+++ b/DCReplace/Config.cs
@@ -1,9 +1,17 @@
-﻿using Exiled.API.Interfaces;
+﻿using System.ComponentModel;
+using Exiled.API.Interfaces;
 
 namespace DCReplace
 {
 	public class Config : IConfig
 	{
+		[Description("Is the plugin enabled?")]
 		public bool IsEnabled { get; set; } = true;
+		[Description("Should the message sent be a hint? Setting to false will use broadcasts.")]
+		public bool UseHints { get; set; } = false;
+		[Description("The message sent to players when they replace someone.")]
+		public string ReplaceMessage { get; set; } = "<i>You have replaced a player who has disconnected.</i>";
+		[Description("Duratation of the message sent to players when they replace someone.")]
+		public ushort MessageDuration { get; set; } = 5;
 	}
 }

--- a/DCReplace/Config.cs
+++ b/DCReplace/Config.cs
@@ -7,6 +7,8 @@ namespace DCReplace
 	{
 		[Description("Is the plugin enabled?")]
 		public bool IsEnabled { get; set; } = true;
+		[Description("Show debug logs?")]
+		public bool Debug { get; set; } = false;
 		[Description("Should the message sent be a hint? Setting to false will use broadcasts.")]
 		public bool UseHints { get; set; } = false;
 		[Description("The message sent to players when they replace someone.")]

--- a/DCReplace/DCReplace.cs
+++ b/DCReplace/DCReplace.cs
@@ -10,7 +10,7 @@ namespace DCReplace
 		{
 			if (!Config.IsEnabled) return;
 
-			_ev = new EventHandlers();
+			_ev = new EventHandlers(this);
 
 			Exiled.Events.Handlers.Player.Left += _ev.OnPlayerLeave;
 			Exiled.Events.Handlers.Scp106.Containing += _ev.OnContain106;

--- a/DCReplace/DCReplace.cs
+++ b/DCReplace/DCReplace.cs
@@ -4,30 +4,30 @@ namespace DCReplace
 {
 	public class DCReplace : Plugin<Config>
 	{
-		private EventHandlers ev;
+		private EventHandlers _ev;
 
 		public override void OnEnabled()
 		{
-			base.OnEnabled();
-
 			if (!Config.IsEnabled) return;
 
-			ev = new EventHandlers();
+			_ev = new EventHandlers();
 
-			Exiled.Events.Handlers.Player.Left += ev.OnPlayerLeave;
-			Exiled.Events.Handlers.Scp106.Containing += ev.OnContain106;
-			Exiled.Events.Handlers.Server.RoundStarted += ev.OnRoundStart;
+			Exiled.Events.Handlers.Player.Left += _ev.OnPlayerLeave;
+			Exiled.Events.Handlers.Scp106.Containing += _ev.OnContain106;
+			Exiled.Events.Handlers.Server.RoundStarted += _ev.OnRoundStart;
+			
+			base.OnEnabled();
 		}
 
 		public override void OnDisabled()
 		{
+			Exiled.Events.Handlers.Player.Left -= _ev.OnPlayerLeave;
+			Exiled.Events.Handlers.Scp106.Containing -= _ev.OnContain106;
+			Exiled.Events.Handlers.Server.RoundStarted -= _ev.OnRoundStart;
+
+			_ev = null;
+			
 			base.OnDisabled();
-
-			Exiled.Events.Handlers.Player.Left -= ev.OnPlayerLeave;
-			Exiled.Events.Handlers.Scp106.Containing -= ev.OnContain106;
-			Exiled.Events.Handlers.Server.RoundStarted -= ev.OnRoundStart;
-
-			ev = null;
 		}
 
 		public override string Name => "DcReplace";

--- a/DCReplace/DCReplace.csproj
+++ b/DCReplace/DCReplace.csproj
@@ -31,21 +31,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=1.2.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\AppData\Roaming\EXILED\Plugins\dependencies\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Desktop\Exiled\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Desktop\scpsls\SCPSL_Data\Managed\Assembly-CSharp.dll</HintPath>
+    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Desktop\Exiled\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Desktop\scpsls\SCPSL_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
-    <Reference Include="CISpy, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\CISpy\CISpy\bin\Release\CISpy.dll</HintPath>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Desktop\Exiled\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="Exiled.API, Version=2.3.3.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\EXILED.2.3.3\lib\net472\Exiled.API.dll</HintPath>
@@ -68,16 +61,14 @@
     <Reference Include="Exiled.Updater, Version=3.1.1.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\EXILED.2.3.3\lib\net472\Exiled.Updater.dll</HintPath>
     </Reference>
-    <Reference Include="Mirror">
-      <HintPath>..\..\..\..\Desktop\References\Mirror.dll</HintPath>
+    <Reference Include="Mirror, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Desktop\Exiled\Mirror.dll</HintPath>
     </Reference>
-    <Reference Include="scp035, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\scp035\scp035\bin\Release\scp035.dll</HintPath>
+    <Reference Include="Scp035, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Desktop\Exiled\Scp035.dll</HintPath>
     </Reference>
-    <Reference Include="SerpentsHand, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\SerpentsHand\SerpentsHand\bin\Release\SerpentsHand.dll</HintPath>
+    <Reference Include="SerpentsHand, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Desktop\Exiled\SerpentsHand.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -87,11 +78,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\Desktop\References\UnityEngine.dll</HintPath>
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Desktop\Exiled\UnityEngine.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\Desktop\References\UnityEngine.CoreModule.dll</HintPath>
+    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\Desktop\Exiled\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/DCReplace/DCReplace.csproj
+++ b/DCReplace/DCReplace.csproj
@@ -78,9 +78,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\..\..\Desktop\Exiled\UnityEngine.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\..\..\Desktop\Exiled\UnityEngine.CoreModule.dll</HintPath>
     </Reference>

--- a/DCReplace/DCReplace.csproj
+++ b/DCReplace/DCReplace.csproj
@@ -40,26 +40,37 @@
     <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\..\..\Desktop\Exiled\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.API, Version=2.3.3.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.3.3\lib\net472\Exiled.API.dll</HintPath>
+    <Reference Include="Exiled.API, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.API.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Bootstrap, Version=2.3.3.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.3.3\lib\net472\Exiled.Bootstrap.dll</HintPath>
+    <Reference Include="Exiled.Bootstrap, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.Bootstrap.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.CreditTags, Version=2.3.3.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.3.3\lib\net472\Exiled.CreditTags.dll</HintPath>
+    <Reference Include="Exiled.CreditTags, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.CreditTags.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Events, Version=2.3.3.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.3.3\lib\net472\Exiled.Events.dll</HintPath>
+    <Reference Include="Exiled.CustomItems, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.CustomItems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Loader, Version=2.3.3.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.3.3\lib\net472\Exiled.Loader.dll</HintPath>
+    <Reference Include="Exiled.Events, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.Events.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Permissions, Version=2.3.3.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.3.3\lib\net472\Exiled.Permissions.dll</HintPath>
+    <Reference Include="Exiled.Loader, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.Loader.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Updater, Version=3.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.3.3\lib\net472\Exiled.Updater.dll</HintPath>
+    <Reference Include="Exiled.Permissions, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.Permissions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Exiled.Updater, Version=3.1.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.Updater.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Mirror, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\..\..\Desktop\Exiled\Mirror.dll</HintPath>

--- a/DCReplace/EventHandlers.cs
+++ b/DCReplace/EventHandlers.cs
@@ -1,10 +1,6 @@
 ﻿using MEC;
 using System.Linq;
-using UnityEngine;
-using scp035.API;
 using System;
-using CISpy.API;
-using System.Collections.Generic;
 using Exiled.Events.EventArgs;
 using Exiled.API.Features;
 using Exiled.API.Enums;
@@ -14,43 +10,31 @@ namespace DCReplace
 {
 	class EventHandlers
 	{
-		private bool isContain106;
-		private bool isRoundStarted = false;
-
-		private Player TryGet035() => Scp035Data.GetScp035();
-
-		private List<Player> TryGetSH() => SerpentsHand.API.SerpentsHand.GetSHPlayers();
-
-		private Dictionary<Player, bool> TryGetSpies() => SpyData.GetSpies();
-
-		private void TrySpawnSpy(Player player, Player dc, Dictionary<Player, bool> spies) => SpyData.MakeSpy(player, spies[dc], false);
-
-		private void TrySpawnSH(Player player) => SerpentsHand.API.SerpentsHand.SpawnPlayer(player, false);
-
-		private void TrySpawn035(Player player) => Scp035Data.Spawn035(player);
+		private bool _isContain106;
+		private bool _isRoundStarted;
 
 		public void OnRoundStart()
 		{
-			isContain106 = false;
-			isRoundStarted = true;
+			_isContain106 = false;
+			_isRoundStarted = true;
 		}
 
-		public void OnRoundEnd() => isRoundStarted = false;
+		public void OnRoundEnd() => _isRoundStarted = false;
 
-		public void OnContain106(ContainingEventArgs ev) => isContain106 = true;
+		public void OnContain106(ContainingEventArgs ev) => _isContain106 = true;
 
 		public void OnPlayerLeave(LeftEventArgs ev)
 		{
-			if (!isRoundStarted || ev.Player.Role == RoleType.Spectator || ev.Player.Position.y < -1997 || (ev.Player.CurrentRoom.Zone == ZoneType.LightContainment && Map.IsLCZDecontaminated)) return;
+			if (!_isRoundStarted || ev.Player.Role == RoleType.Spectator || ev.Player.Position.y < -1997 || (ev.Player.CurrentRoom.Zone == ZoneType.LightContainment && Map.IsLCZDecontaminated)) return;
 
-			bool is035 = false;
-			bool isSH = false;
-			if (isContain106 && ev.Player.Role == RoleType.Scp106) return;
-			Dictionary<Player, bool> spies = null;
+			var is035 = false;
+			var isSH = false;
+			
+			if (_isContain106 && ev.Player.Role == RoleType.Scp106) return;
 			var role = Loader.Plugins.FirstOrDefault(pl => pl.Name == "EasyEvents")?.Assembly.GetType("EasyEvents.Util")?.GetMethod("GetRole")?.Invoke(null, new object[] {ev.Player});
 			try
 			{
-				is035 = ev.Player.Id == TryGet035()?.Id;
+				is035 = Scp035.API.IsScp035(ev.Player);
 			}
 			catch (Exception x)
 			{
@@ -59,30 +43,21 @@ namespace DCReplace
 
 			try
 			{
-				isSH = TryGetSH().Contains(ev.Player);
+				isSH = SerpentsHand.API.IsSerpent(ev.Player);
 			}
 			catch (Exception x)
 			{
 				Log.Debug("Serpents Hand is not installed, skipping method call...");
 			}
 
-			try
-			{
-				spies = TryGetSpies();
-			}
-			catch (Exception x)
-			{
-				Log.Debug("CISpy is not installed, skipping method call...");
-			}
-			
-			Player player = Player.List.FirstOrDefault(x => x.Role == RoleType.Spectator && x.UserId != string.Empty && x.UserId != ev.Player.UserId && !x.IsOverwatchEnabled);
-			if (player != null)
+			var player = Player.List.FirstOrDefault(x => x.Role == RoleType.Spectator && x.UserId != string.Empty && x.UserId != ev.Player.UserId && !x.IsOverwatchEnabled);
+			if (player == null) return;
 			{
 				if (isSH)
 				{
 					try
 					{
-						TrySpawnSH(player);
+						SerpentsHand.API.SpawnPlayer(player);
 					}
 					catch (Exception x)
 					{
@@ -90,22 +65,11 @@ namespace DCReplace
 					}
 				}
 				else player.SetRole(ev.Player.Role);
-				if (spies != null && spies.ContainsKey(ev.Player))
-				{
-					try
-					{
-						TrySpawnSpy(player, ev.Player, spies);
-					}
-					catch (Exception x)
-					{
-						Log.Debug("CISpy is not installed, skipping method call...");
-					}
-				}
 				if (is035)
 				{
 					try
 					{
-						TrySpawn035(player);
+						Scp035.API.Spawn035(player);
 					}
 					catch (Exception x)
 					{
@@ -114,12 +78,12 @@ namespace DCReplace
 				}
 
 				// save info
-				Vector3 pos = ev.Player.Position;
+				var pos = ev.Player.Position;
 				var inventory = ev.Player.Inventory.items.Select(x => x.id).ToList();
-				float health = ev.Player.Health;
-				uint ammo1 = ev.Player.Ammo[(int)AmmoType.Nato556];
-				uint ammo2 = ev.Player.Ammo[(int)AmmoType.Nato762];
-				uint ammo3 = ev.Player.Ammo[(int)AmmoType.Nato9];
+				var health = ev.Player.Health;
+				var ammo1 = ev.Player.Ammo[(int)AmmoType.Nato556];
+				var ammo2 = ev.Player.Ammo[(int)AmmoType.Nato762];
+				var ammo3 = ev.Player.Ammo[(int)AmmoType.Nato9];
 
 				Timing.CallDelayed(0.3f, () =>
 				{

--- a/DCReplace/EventHandlers.cs
+++ b/DCReplace/EventHandlers.cs
@@ -13,6 +13,13 @@ namespace DCReplace
 		private bool _isContain106;
 		private bool _isRoundStarted;
 
+		private readonly DCReplace _plugin;
+
+		public EventHandlers(DCReplace plugin)
+		{
+			_plugin = plugin;
+		}
+
 		public void OnRoundStart()
 		{
 			_isContain106 = false;
@@ -38,7 +45,7 @@ namespace DCReplace
 			}
 			catch (Exception x)
 			{
-				Log.Debug("SCP-035 is not installed, skipping method call...");
+				Log.Debug($"SCP-035 is not installed, skipping method call... {x}");
 			}
 
 			try
@@ -47,7 +54,7 @@ namespace DCReplace
 			}
 			catch (Exception x)
 			{
-				Log.Debug("Serpents Hand is not installed, skipping method call...");
+				Log.Debug($"Serpents Hand is not installed, skipping method call... {x}");
 			}
 
 			var player = Player.List.FirstOrDefault(x => x.Role == RoleType.Spectator && x.UserId != string.Empty && x.UserId != ev.Player.UserId && !x.IsOverwatchEnabled);
@@ -61,7 +68,7 @@ namespace DCReplace
 					}
 					catch (Exception x)
 					{
-						Log.Debug("Serpents Hand is not installed, skipping method call...");
+						Log.Debug($"Serpents Hand is not installed, skipping method call... {x}");
 					}
 				}
 				else player.SetRole(ev.Player.Role);
@@ -73,7 +80,7 @@ namespace DCReplace
 					}
 					catch (Exception x)
 					{
-						Log.Debug("SCP-035 is not installed, skipping method call...");
+						Log.Debug($"SCP-035 is not installed, skipping method call... {x}");
 					}
 				}
 
@@ -94,7 +101,16 @@ namespace DCReplace
 					player.Ammo[(int)AmmoType.Nato556] = ammo1;
 					player.Ammo[(int)AmmoType.Nato762] = ammo2;
 					player.Ammo[(int)AmmoType.Nato9] = ammo3;
-					player.Broadcast(5, "<i>You have replaced a player who has disconnected.</i>");
+
+					if (_plugin.Config.UseHints)
+					{
+						player.ShowHint(_plugin.Config.ReplaceMessage, _plugin.Config.MessageDuration);
+					}
+					else
+					{
+						player.Broadcast(_plugin.Config.MessageDuration, _plugin.Config.ReplaceMessage);
+					}
+
 					if(role != null) Loader.Plugins.FirstOrDefault(pl => pl.Name == "EasyEvents")?.Assembly.GetType("EasyEvents.CustomRoles")?.GetMethod("ChangeRole")?.Invoke(null, new object[] {player, role});
 				});
 			}

--- a/DCReplace/EventHandlers.cs
+++ b/DCReplace/EventHandlers.cs
@@ -32,29 +32,34 @@ namespace DCReplace
 
 		public void OnPlayerLeave(LeftEventArgs ev)
 		{
+			Log.Debug($"{ev.Player.Nickname} Left the server. Role: {ev.Player.Role}", _plugin.Config.Debug);
+
 			if (!_isRoundStarted || ev.Player.Role == RoleType.Spectator || ev.Player.Position.y < -1997 || (ev.Player.CurrentRoom.Zone == ZoneType.LightContainment && Map.IsLCZDecontaminated)) return;
 
 			var is035 = false;
 			var isSH = false;
+			var spawnDelay = .3f;
 			
 			if (_isContain106 && ev.Player.Role == RoleType.Scp106) return;
 			var role = Loader.Plugins.FirstOrDefault(pl => pl.Name == "EasyEvents")?.Assembly.GetType("EasyEvents.Util")?.GetMethod("GetRole")?.Invoke(null, new object[] {ev.Player});
 			try
 			{
 				is035 = Scp035.API.IsScp035(ev.Player);
+				Log.Debug($"Player was 035: {is035}", _plugin.Config.Debug);
 			}
 			catch (Exception x)
 			{
-				Log.Debug($"SCP-035 is not installed, skipping method call... {x}");
+				Log.Debug($"SCP-035 is not installed, skipping method call... {x}", _plugin.Config.Debug);
 			}
 
 			try
 			{
 				isSH = SerpentsHand.API.IsSerpent(ev.Player);
+				Log.Debug($"Player was SH: {isSH}", _plugin.Config.Debug);
 			}
 			catch (Exception x)
 			{
-				Log.Debug($"Serpents Hand is not installed, skipping method call... {x}");
+				Log.Debug($"Serpents Hand is not installed, skipping method call... {x}", _plugin.Config.Debug);
 			}
 
 			var player = Player.List.FirstOrDefault(x => x.Role == RoleType.Spectator && x.UserId != string.Empty && x.UserId != ev.Player.UserId && !x.IsOverwatchEnabled);
@@ -65,22 +70,30 @@ namespace DCReplace
 					try
 					{
 						SerpentsHand.API.SpawnPlayer(player);
+						//This is to accomodate for SH spawn time.
+						spawnDelay = .6f;
+						Log.Debug($"Replacing {ev.Player.Nickname} with {player.Nickname}. Role: Serpents Hand", _plugin.Config.Debug);
 					}
 					catch (Exception x)
 					{
-						Log.Debug($"Serpents Hand is not installed, skipping method call... {x}");
+						Log.Debug($"Serpents Hand is not installed, skipping method call... {x}", _plugin.Config.Debug);
 					}
 				}
-				else player.SetRole(ev.Player.Role);
+				else
+				{
+					player.SetRole(ev.Player.Role);
+					Log.Debug($"Replacing {ev.Player.Nickname} with {player.Nickname}. Role: {ev.Player.Role}", _plugin.Config.Debug);
+				}
 				if (is035)
 				{
 					try
 					{
 						Scp035.API.Spawn035(player);
+						Log.Debug($"Setting {player.Nickname} to SCP-035", _plugin.Config.Debug);
 					}
 					catch (Exception x)
 					{
-						Log.Debug($"SCP-035 is not installed, skipping method call... {x}");
+						Log.Debug($"SCP-035 is not installed, skipping method call... {x}", _plugin.Config.Debug);
 					}
 				}
 
@@ -92,7 +105,7 @@ namespace DCReplace
 				var ammo2 = ev.Player.Ammo[(int)AmmoType.Nato762];
 				var ammo3 = ev.Player.Ammo[(int)AmmoType.Nato9];
 
-				Timing.CallDelayed(0.3f, () =>
+				Timing.CallDelayed(spawnDelay, () =>
 				{
 					player.Position = pos;
 					player.ClearInventory();

--- a/DCReplace/packages.config
+++ b/DCReplace/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EXILED" version="2.3.3" targetFramework="net472" />
+  <package id="EXILED" version="2.11.1" targetFramework="net472" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Replaces a player with a random spectator if they get disconnected.
 
-Compatible with [Serpents Hand](https://github.com/Cyanox62/SerpentsHand/tree/exiled), [CISpy](https://github.com/Cyanox62/CISpy/tree/exiled), and [SCP-035](https://github.com/Cyanox62/scp035/tree/exiled).
+Compatible with [Serpents Hand](https://github.com/Michal78900/SerpentsHand) and [SCP-035](https://github.com/Exiled-Team/Scp035).
 
 # Installation
 


### PR DESCRIPTION
This fixes support for SCP-035 and Serpents Hand.
Also adds additional config for using hints or broadcasts as well setting the broadcast message and length.
Removed CISpy because the original plugin is no longer supported.
General code cleanup.

I have tested in my server and it works well.